### PR TITLE
Merge Development for v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [1.5.3] - 2021-08-28
+
+Just a small bugfix in this release. Previously if a layer's offset was (0, 0), the values for it would not appear in the JSON file, so the `offset` value in the
+Layer class would be `None`. This can cause some unexpected behavior in engines or games, and puts the responsibility of checking if this value exists onto the game or engine using it.
+
+This value has been changed to default to (0, 0) if it is not present in the JSON so that games can apply it easily in one line and always get the same result without error.
+
 ## [1.5.2] - 2021-07-28
 
 This release contains some re-working to properly support templates.

--- a/pytiled_parser/layer.py
+++ b/pytiled_parser/layer.py
@@ -56,10 +56,10 @@ class Layer:
 
     coordinates: OrderedPair = OrderedPair(0, 0)
     parallax_factor: OrderedPair = OrderedPair(1, 1)
+    offset: OrderedPair = OrderedPair(0, 0)
 
     id: Optional[int] = None
     size: Optional[Size] = None
-    offset: Optional[OrderedPair] = None
     properties: Optional[properties_.Properties] = None
     tint_color: Optional[Color] = None
 

--- a/pytiled_parser/version.py
+++ b/pytiled_parser/version.py
@@ -1,3 +1,3 @@
 """pytiled_parser version"""
 
-__version__ = "1.5.2"
+__version__ = "1.5.3"

--- a/tests/test_data/layer_tests/all_layer_types/expected.py
+++ b/tests/test_data/layer_tests/all_layer_types/expected.py
@@ -108,6 +108,7 @@ EXPECTED = [
     ),
     layer.ImageLayer(
         name="Image Layer 1",
+        offset=common_types.OrderedPair(1, 4),
         opacity=1,
         visible=True,
         id=3,
@@ -117,6 +118,7 @@ EXPECTED = [
     ),
     layer.ImageLayer(
         name="Image Layer 2",
+        offset=common_types.OrderedPair(0, 0),
         opacity=1,
         visible=True,
         id=5,

--- a/tests/test_data/layer_tests/all_layer_types/map.json
+++ b/tests/test_data/layer_tests/all_layer_types/map.json
@@ -64,6 +64,8 @@
          "id":3,
          "image":"..\/..\/images\/tile_04.png",
          "name":"Image Layer 1",
+         "offsetx":1,
+         "offsety":4,
          "opacity":1,
          "tintcolor":"#ff0000",
          "transparentcolor":"#000000",
@@ -88,7 +90,7 @@
  "nextobjectid":3,
  "orientation":"orthogonal",
  "renderorder":"right-down",
- "tiledversion":"1.6.0",
+ "tiledversion":"1.7.2",
  "tileheight":32,
  "tilesets":[
         {


### PR DESCRIPTION
Fixes for 1.5.3 which includes changing the default value for offset of a layer to (0, 0) rather than None